### PR TITLE
Adicionando método para retornar se região do GTIN é restrita

### DIFF
--- a/src/Gtin.php
+++ b/src/Gtin.php
@@ -248,18 +248,13 @@ final class Gtin
      */
     protected function getPrefixRegion(string $prefix): string
     {
-        $pf = (int) $prefix;
-        foreach ($this->stdPrefixCollection as $std) {
-            $nI = (int) $std->nIni;
-            $nF = (int) $std->nFim;
-            $this->validPrefix = true;
-            $region = $std->region;
-            if ($pf >= $nI && $pf <= $nF) {
-                return $region;
-            }
+        $prefixDefinition = $this->getPrefixDefinition($prefix);
+        if ($prefixDefinition === null) {
+            $this->validPrefix = false;
+            return "Not Found";
         }
-        $this->validPrefix = false;
-        return "Not Found";
+        $this->validPrefix = true;
+        return $prefixDefinition->getRegion();
     }
 
     /**
@@ -280,5 +275,28 @@ final class Gtin
             $dv = 0;
         }
         return $dv;
+    }
+
+    protected function getPrefixDefinition(string $prefix): ?PrefixDefinition
+    {
+        foreach ($this->stdPrefixCollection as $std) {
+            $definition = new PrefixDefinition($std);
+            if ($definition->hasPrefix($prefix)) {
+                return $definition;
+            }
+        }
+
+        return null;
+    }
+
+
+    public function isRestricted(): bool
+    {
+        $prefixDefinition = $this->getPrefixDefinition($this->prefix);
+        if ($prefixDefinition === null) {
+            throw new \RuntimeException("{$this->prefix} is not a valid prefix!");
+        }
+
+        return $prefixDefinition->isRestricted();
     }
 }

--- a/src/PrefixDefinition.php
+++ b/src/PrefixDefinition.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NFePHP\Gtin;
+
+class PrefixDefinition
+{
+    private \stdClass $std;
+
+    public function __construct(\stdClass $std)
+    {
+        $this->std = $std;
+    }
+
+    public function getRegion(): string
+    {
+        return (string)$this->std->region;
+    }
+
+    public function hasPrefix(string $prefix): bool
+    {
+        $pf = (int) $prefix;
+        $nI = (int) $this->std->nIni;
+        $nF = (int) $this->std->nFim;
+        return $pf >= $nI && $pf <= $nF;
+    }
+
+    public function isRestricted(): bool
+    {
+        return $this->std->restricted == "1";
+    }
+
+}

--- a/tests/GtinTest.php
+++ b/tests/GtinTest.php
@@ -20,8 +20,8 @@ class GtinTest extends TestCase
     /**
      * Can instantiate class test
      *
-     * @covers Gtin
-     * @covers ::__contruct
+     * @covers \NFePHP\Gtin\Gtin
+     * @covers \NFePHP\Gtin\Gtin::__construct()
      */
     public function testCanInstantiate(): void
     {
@@ -32,9 +32,9 @@ class GtinTest extends TestCase
     /**
      * Can instantiate static class test
      *
-     * @covers Gtin
-     * @covers ::__contruct
-     * @covers ::check
+     * @covers \NFePHP\Gtin\Gtin
+     * @covers \NFePHP\Gtin\Gtin::__construct()
+     * @covers \NFePHP\Gtin\Gtin::check()
      */
     public function testCanInstantiateStatic(): void
     {
@@ -45,7 +45,7 @@ class GtinTest extends TestCase
     /**
      * Region test
      *
-     * @covers Gtin::getPrefixRegion
+     * @covers \NFePHP\Gtin\Gtin::getPrefixRegion()
      */
     public function testRegion(): void
     {
@@ -59,7 +59,7 @@ class GtinTest extends TestCase
     /**
      * Check digit test
      *
-     * @covers Gtin::getCheckDigit
+     * @covers \NFePHP\Gtin\Gtin::getCheckDigit()
      */
     public function testCheckDigit(): void
     {
@@ -73,8 +73,8 @@ class GtinTest extends TestCase
     /**
      * Prefix test
      *
-     * @covers Gtin::getPrefix
-     * @covers Gtin::getType
+     * @covers \NFePHP\Gtin\Gtin::getPrefix()
+     * @covers \NFePHP\Gtin\Gtin::getType()
      */
     public function testPrefix(): void
     {
@@ -85,7 +85,7 @@ class GtinTest extends TestCase
     /**
      * Gtin is Valid
      *
-     * @covers Gtin::isValid
+     * @covers \NFePHP\Gtin\Gtin::isValid()
      */
     public function testIsValid(): void
     {
@@ -96,7 +96,7 @@ class GtinTest extends TestCase
     /**
      * SEM GTIN is Valid
      *
-     * @covers Gtin::isValid
+     * @covers \NFePHP\Gtin\Gtin::isValid()
      */
     public function testSemGetin(): void
     {
@@ -231,5 +231,21 @@ class GtinTest extends TestCase
         );
 
         Gtin::check('07890142547852')->isValid();
+    }
+
+    public function test_is_restricted(): void
+    {
+        $gtin = new Gtin('2244000425601');
+        $this->assertTrue($gtin->isRestricted());
+
+        $gtin = new Gtin('7909934485750');
+        $this->assertFalse($gtin->isRestricted());
+    }
+
+    public function test_is_restricted_invalid_prefix(): void
+    {
+        $this->expectErrorMessage("510 is not a valid prefix!");
+        $gtin = new Gtin('5109907267612');
+        $gtin->isRestricted();
     }
 }

--- a/tests/PrefixDefinitionTest.php
+++ b/tests/PrefixDefinitionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace NFePHP\Gtin\Tests;
+
+use NFePHP\Gtin\PrefixDefinition;
+use PHPUnit\Framework\TestCase;
+
+class PrefixDefinitionTest extends TestCase
+{
+
+    public function test_is_restricted(): void
+    {
+        $definition = new PrefixDefinition((object)[
+            "nIni" => "000",
+            "nFim" => "019",
+            "restricted" => "0",
+            "region" => "GS1 US"
+        ]);
+        $this->assertFalse($definition->isRestricted());
+    }
+
+    public function test_is_not_restricted(): void
+    {
+        $definition = new PrefixDefinition((object)[
+            "nIni" => "020",
+            "nFim" => "029",
+            "restricted" => "1",
+            "region" => "Números de circulação restrita dentro da região"
+        ]);
+        $this->assertTrue($definition->isRestricted());
+    }
+
+    public function test_get_region(): void
+    {
+        $definition = new PrefixDefinition((object)[
+            "nIni" => "020",
+            "nFim" => "029",
+            "restricted" => "1",
+            "region" => "Números de circulação restrita dentro da região"
+        ]);
+        $this->assertEquals("Números de circulação restrita dentro da região", $definition->getRegion());
+    }
+
+    public function testHasPrefix(): void
+    {
+        $definition = new PrefixDefinition((object)[
+            "nIni" => "020",
+            "nFim" => "029",
+            "restricted" => "1",
+            "region" => "Números de circulação restrita dentro da região"
+        ]);
+
+        $this->assertFalse($definition->hasPrefix("999"));
+        $this->assertFalse($definition->hasPrefix("030"));
+        $this->assertTrue($definition->hasPrefix("020"));
+        $this->assertTrue($definition->hasPrefix("021"));
+        $this->assertTrue($definition->hasPrefix("029"));
+    }
+}


### PR DESCRIPTION
Também isolei a lógica para tratamento da região, diminuindo assim a responsabilidade da classe Gtin
Essa informação é útil no meu caso para não enviar o GTIN para o Mercado Livre.